### PR TITLE
Draft:Fixed container timezone drift

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -5,7 +5,7 @@ printf "\n>>> Removing running Home Assistant\n"
 podman-compose down || true
 
 printf "\n>>> Starting Home Assistant\n"
-podman-compose up -d --build
+podman-compose --podman-run-args="--tz=local" up -d --build
 
 watch() {
     printf "\n>>> Watching folder $1/ for changes...\n"

--- a/start-local.sh
+++ b/start-local.sh
@@ -13,6 +13,7 @@ podman rm -f mock-api || true
 
 printf "\n>>> Starting Mock API container\n"
 podman run -d --name mock-api \
+--tz=local \
 --network $PROJECT \
 -p 4000:4000 \
 mock-api
@@ -26,6 +27,7 @@ podman rm -f homeassistant || true
 printf "\n>>> Starting Home Assistant container\n"
 podman run -d --name homeassistant \
 --network $PROJECT \
+--tz=local \
 --cap-add=CAP_NET_RAW,CAP_NET_BIND_SERVICE \
 --restart=unless-stopped \
 -p 8123:8123 \


### PR DESCRIPTION
---
name: Fixed container timezone drift
about: Containers might have timezone different from the machine on which they are run, causing issues when authorizing hacs with github. Podman has an option to set timezone of the container on startup.
author: ''

---

## Description

Updated podman startup scripts with --tz=local optional.

## How to test

Start the application, attach shell to the container, check date and time with `date` command.

## Checklist

- [ ] Change is covered by unit test (if it makes sense)
- [ ] Changelog is updated
- [ ] Integration version is increased (major/minor/bugfix)
